### PR TITLE
EPM-47 - Open Response Assessment tab for Instructor Dashboard

### DIFF
--- a/lms/djangoapps/instructor/admin.py
+++ b/lms/djangoapps/instructor/admin.py
@@ -17,7 +17,8 @@ def available_sections_bulk_action(field, is_set):
 
 class InstructorAvailableSectionsAdmin(ForeignKeyAutocompleteAdmin):
     bulk_fields_names = ['show_course_info', 'show_membership', 'show_cohort', 'show_student_admin',
-                                  'show_data_download', 'show_email', 'show_analytics', 'show_studio_link']
+                         'show_data_download', 'show_email', 'show_analytics', 'show_studio_link',
+                         'show_open_responses']
 
     list_display = ['user'] + bulk_fields_names
 


### PR DESCRIPTION
New Open Response Assessment tab in the Instructor Dashboard of LMS:
https://projects.invisionapp.com/share/YKA6S7VH8#/216097426_Course_-Instructor_-AppsAndTools

Screenshots:

![001](https://cloud.githubusercontent.com/assets/1876893/23239313/84fc2320-f977-11e6-8727-02a275129b0b.jpg)

![002](https://cloud.githubusercontent.com/assets/1876893/23239314/84fd432c-f977-11e6-89fc-c81eafff0721.jpg)

![003](https://cloud.githubusercontent.com/assets/1876893/23239312/84fa8f60-f977-11e6-94ae-1e2480c0008b.jpg)
